### PR TITLE
Fix issue 1 - Branch Master is not the starting point

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,11 @@ dependencies {
     androidTestImplementation "androidx.test:core-ktx:$androidx_test_version"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
-    kaptAndroidTest "com.google.dagger:dagger-compiler:$dagger_version"
+    // Dagger dependencies
+    implementation "com.google.dagger:dagger:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
 
+    // Dagger testing
+    kaptTest "com.google.dagger:dagger-compiler:$dagger_version"
+    kaptAndroidTest "com.google.dagger:dagger-compiler:$dagger_version"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'dagger.hilt.android.plugin'
 
 android {
     compileSdkVersion 29
@@ -60,11 +59,4 @@ dependencies {
 
     kaptAndroidTest "com.google.dagger:dagger-compiler:$dagger_version"
 
-    // Hilt dependencies
-    implementation "com.google.dagger:hilt-android:$hilt_version"
-    kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
-
-    // Hilt testing
-    androidTestImplementation "com.google.dagger:hilt-android-testing:$hilt_version"
-    kaptAndroidTest "com.google.dagger:hilt-android-compiler:$hilt_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
From [Issue 1: Branch Master is not the starting point](https://github.com/googlecodelabs/android-dagger-to-hilt/issues/1) 
related by [@evowizz](https://github.com/evowizz) . Thanks!

## Problem to solve: 

According to page #2 of the codelab, we are supposed to add Hilt to the project ourselves. However, as seen in the following lines, Hilt is already included in this project in Master.

**android-dagger-to-hilt/build.gradle** Line 5 in 267db26
<pre>ext.hilt_version = '2.28-alpha'   </pre>

**android-dagger-to-hilt/build.gradle** Line 13 in 267db26
<pre>classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version" </pre>

**android-dagger-to-hilt/app/build.gradle** Line 9 in 267db26
<pre>apply plugin: 'dagger.hilt.android.plugin' </pre>

**android-dagger-to-hilt/app/build.gradle** Lines 71 to 73 in 267db26
<pre>// Hilt dependencies
implementation "com.google.dagger:hilt-android:$hilt_version" 
kapt "com.google.dagger:hilt-android-compiler:$hilt_version"  </pre>

Moreover, this also prevent us from running the project at its starting point, because Hilt produces the following issue:
<pre> 
com\example\android\dagger\di\AppSubcomponents.java:7: error: [Hilt]
public final class AppSubcomponents {
             ^
  com.example.android.dagger.di.AppSubcomponents must also be annotated with @InstallIn.
  [Hilt] Processing did not complete. See error above for details
</pre>

 ## Solution proposal:

1.  Remove Hilt dependencies.
2. Setup Dagger dependencies.